### PR TITLE
Footer: Fix Typo

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -25,7 +25,7 @@ class Footer extends React.Component {
               {children}
               <li className="link">
                 <a href="https://github.com/kaishin" rel="me">
-                  Github
+                  GitHub
                 </a>
                 <span className="separator">/</span>
               </li>


### PR DESCRIPTION
GitHub uses a capital 'H' 🤓

https://github.com
<img width="528" alt="Screen Shot 2020-08-31 at 7 45 58 AM" src="https://user-images.githubusercontent.com/4723115/91733159-0f0a2e00-eb5e-11ea-9f49-5656f138e4f8.png">
