### PR TITLE
Improve dark mode color scheme handling

### DIFF
--- a/src/components/ThemeSelect.astro
+++ b/src/components/ThemeSelect.astro
@@ -53,34 +53,63 @@ import { Moon, Sun } from "@lucide/astro";
 </style>
 
 <script is:inline>
-  const handleSelectChange = (event) => {
-    const theme = event.target.value;
-    const element = document.documentElement;
+  (() => {
+    const select = document.getElementById("themeSelect");
+    const root = document.documentElement;
+    const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+    const systemScheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-    if (theme === "system") {
-      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-        element.classList.add("dark");
+    const setColorScheme = (theme) => {
+      colorSchemeMeta?.setAttribute(
+        "content",
+        theme === "system" ? "light dark" : theme,
+      );
+    };
+
+    const applyTheme = (theme) => {
+      const resolvedTheme =
+        theme === "system" ? (systemScheme.matches ? "dark" : "light") : theme;
+
+      root.classList.toggle("dark", resolvedTheme === "dark");
+      setColorScheme(theme);
+
+      if (select) {
+        select.value = theme;
+      }
+    };
+
+    const saveTheme = (theme) => {
+      if (theme === "system") {
+        localStorage.removeItem("theme");
       } else {
-        element.classList.remove("dark");
+        localStorage.setItem("theme", theme);
       }
 
-      localStorage.removeItem("theme");
-      document.getElementById("themeSelect").value = "system";
-    } else if (theme === "light") {
-      element.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-      document.getElementById("themeSelect").value = "light";
-    } else if (theme === "dark") {
-      element.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-      document.getElementById("themeSelect").value = "dark";
+      applyTheme(theme);
+    };
+
+    const storedTheme = localStorage.getItem("theme");
+    const theme =
+      storedTheme === "light" || storedTheme === "dark"
+        ? storedTheme
+        : "system";
+
+    applyTheme(theme);
+
+    select?.addEventListener("change", (event) => {
+      saveTheme(event.target.value);
+    });
+
+    const handleSystemChange = () => {
+      if (!localStorage.getItem("theme")) {
+        applyTheme("system");
+      }
+    };
+
+    if (systemScheme.addEventListener) {
+      systemScheme.addEventListener("change", handleSystemChange);
+    } else {
+      systemScheme.addListener(handleSystemChange);
     }
-  };
-
-  const theme = localStorage.getItem("theme") || "system";
-  handleSelectChange({ target: { value: theme } });
-
-  document
-    .getElementById("themeSelect")
-    .addEventListener("change", handleSelectChange);
+  })();
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -32,6 +32,7 @@ if (title != SITE_TITLE) {
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <meta name="color-scheme" content="light dark" />
 
     <!-- SEO -->
     <meta name="robots" content="noodp, noydir" />
@@ -100,15 +101,30 @@ if (title != SITE_TITLE) {
 
     <!-- Dark Mode -->
     <script is:inline>
-      if (
-        localStorage.theme === "dark" ||
-        (!("theme" in localStorage) &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches)
-      ) {
-        document.documentElement.classList.add("dark");
-      } else {
-        document.documentElement.classList.remove("dark");
-      }
+      (() => {
+        const storedTheme = localStorage.getItem("theme");
+        const systemPrefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)",
+        ).matches;
+        const resolvedTheme =
+          storedTheme === "dark" ||
+          (storedTheme !== "light" && systemPrefersDark)
+            ? "dark"
+            : "light";
+
+        document.documentElement.classList.toggle(
+          "dark",
+          resolvedTheme === "dark",
+        );
+        document
+          .querySelector('meta[name="color-scheme"]')
+          ?.setAttribute(
+            "content",
+            storedTheme === "light" || storedTheme === "dark"
+              ? storedTheme
+              : "light dark",
+          );
+      })();
     </script>
 
     <!-- GoatCounter -->


### PR DESCRIPTION
## Summary
- advertise light and dark color schemes early via meta
- keep the color-scheme meta tag in sync with explicit light/dark overrides
- update system theme mode when the OS color scheme changes while the page is open

## Validation
- ./node_modules/.bin/astro build

Note: pnpm run build is blocked in this Codex environment before running the script by pnpm's ignored-builds approval gate for esbuild and sharp.